### PR TITLE
Update the source example in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ By default, yang2-rs uses pre-generated FFI bindings and uses dynamic linking to
 A basic example that parses and validates JSON instance data, and then converts
 it to the XML format:
 ```rust,no_run
+use std::sync::Arc;
 use std::fs::File;
 use yang2::context::{Context, ContextFlags};
 use yang2::data::{
@@ -59,7 +60,7 @@ static SEARCH_DIR: &str = "./assets/yang/";
 
 fn main() -> std::io::Result<()> {
     // Initialize context.
-    let ctx = Context::new(ContextFlags::NO_YANGLIBRARY)
+    let mut ctx = Context::new(ContextFlags::NO_YANGLIBRARY)
         .expect("Failed to create context");
     ctx.set_searchdir(SEARCH_DIR)
         .expect("Failed to set YANG search directory");
@@ -69,6 +70,7 @@ fn main() -> std::io::Result<()> {
         ctx.load_module(module_name, None, &[])
             .expect("Failed to load module");
     }
+    let ctx = Arc::new(ctx);
 
     // Parse and validate data tree in the JSON format.
     let dtree = DataTree::parse_file(

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() -> std::io::Result<()> {
         File::open("./assets/data/interfaces.json")?,
         DataFormat::JSON,
         DataParserFlags::empty(),
-        DataValidationFlags::empty(),
+        DataValidationFlags::NO_STATE,
     )
     .expect("Failed to parse data tree");
 
@@ -95,6 +95,7 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
+Note the `NO_STATE` flag passed to `parse_file` since the example json file does not contain state data.
 More examples can be found [here][examples].
 
 [examples]: https://github.com/rwestphal/yang2-rs/tree/master/examples


### PR DESCRIPTION
I have updated the README code so it compiles.  Using the data in the existing `assets` folder, I get the following error:

```console
libyang[0]: Mandatory node "oper-status" instance does not exist. (path: Schema location "/ietf-interfaces:interfaces/interface/oper-status", line number 20.)
thread 'main' panicked at 'Failed to parse data tree: Error { errcode: 7, msg: Some("Mandatory node \"oper-status\" instance does not exist."), path: Some("Schema location \"/ietf-interfaces:interfaces/interface
/oper-status\", line number 20."), apptag: None }', src/bin/dewit.rs:33:6
```

This is easily resolved by adding

```json
"oper-status": "up",
"statistics": {
  "discontinuity-time": "2019-08-08T10:11:12.345+09:01"
}
```

to the interfaces container.
I would be happy to update the `interfaces.json` file or include a note about the expected failure.  I will leave that up to your discretion.  Thanks!